### PR TITLE
Update README to add a step for running locally

### DIFF
--- a/youtube-subtitles-extractor/containerapp/README.md
+++ b/youtube-subtitles-extractor/containerapp/README.md
@@ -37,7 +37,14 @@ This is an MCP server, hosted on [Azure Container Apps](https://learn.microsoft.
     $REPOSITORY_ROOT = git rev-parse --show-toplevel
     ```
 
-1. Run the MCP server app.
+1. Comment out the `UseMcpAuth()` line in [Program.cs](./src/McpYouTubeSubtitlesExtractor.ContainerApp/Program.cs) to disable API key validation for local development.
+
+    ```bash
+    # In Program.cs, comment out this line:
+    # app.UseMcpAuth();
+    ```
+
+2. Run the MCP server app.
 
     ```bash
     cd $REPOSITORY_ROOT/youtube-subtitles-extractor/containerapp


### PR DESCRIPTION
Add a step in the README to guide users on how to disable API key validation for local development by commenting out a specific line in the Program.cs file.

## Purpose
* This change enables API key validation for the application via an HTTP header. By uncommenting the `app.UseMcpAuth()` middleware, the application will now require a valid API key to be passed in the HTTP header for accessing protected endpoints.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] New feature to existing sample
[ ] New sample
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[X] N/A
```

