### PR TITLE
Remove chatmodes from metadata update script

### DIFF
--- a/awesome-copilot/update-metadata.js
+++ b/awesome-copilot/update-metadata.js
@@ -26,13 +26,8 @@ const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
 
 // Define the directories to process
 const directories = {
-    chatmodes: path.join(__dirname, "src", "awesome-copilot", "chatmodes"),
-    instructions: path.join(
-        __dirname,
-        "src",
-        "awesome-copilot",
-        "instructions"
-    ),
+    // chatmodes: path.join(__dirname, "src", "awesome-copilot", "chatmodes"),
+    instructions: path.join(__dirname, "src", "awesome-copilot", "instructions"),
     prompts: path.join(__dirname, "src", "awesome-copilot", "prompts"),
     collections: path.join(__dirname, "src", "awesome-copilot", "collections"),
     agents: path.join(__dirname, "src", "awesome-copilot", "agents"),
@@ -663,11 +658,8 @@ function processCollectionDirectory(dirPath) {
 
 // Process all directories
 const metadata = {
-    chatmodes: processDirectory(directories.chatmodes, ".chatmode.md"),
-    instructions: processDirectory(
-        directories.instructions,
-        ".instructions.md"
-    ),
+    // chatmodes: processDirectory(directories.chatmodes, ".chatmode.md"),
+    instructions: processDirectory(directories.instructions, ".instructions.md"),
     prompts: processDirectory(directories.prompts, ".prompt.md"),
     collections: processCollectionDirectory(directories.collections),
     agents: processDirectory(directories.agents, ".agent.md"),
@@ -682,9 +674,9 @@ const outputPath = path.join(
 );
 fs.writeFileSync(outputPath, JSON.stringify(metadata, null, 2));
 
-console.log(
-    `Extracted frontmatter from ${metadata.chatmodes.length} chatmode files`
-);
+// console.log(
+//     `Extracted frontmatter from ${metadata.chatmodes.length} chatmode files`
+// );
 console.log(
     `Extracted frontmatter from ${metadata.instructions.length} instruction files`
 );
@@ -702,17 +694,17 @@ console.log(`Metadata written to ${outputPath}`);
 // Validate that required fields are present
 let hasErrors = false;
 
-// Check chatmodes
-metadata.chatmodes.forEach((chatmode) => {
-    if (!chatmode.filename || !chatmode.description) {
-        console.error(
-            `Error: Chatmode missing required fields: ${
-                chatmode.filename || "unknown"
-            }`
-        );
-        hasErrors = true;
-    }
-});
+// // Check chatmodes
+// metadata.chatmodes.forEach((chatmode) => {
+//     if (!chatmode.filename || !chatmode.description) {
+//         console.error(
+//             `Error: Chatmode missing required fields: ${
+//                 chatmode.filename || "unknown"
+//             }`
+//         );
+//         hasErrors = true;
+//     }
+// });
 
 // Check instructions
 metadata.instructions.forEach((instruction) => {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove chatmodes processing from the `update-metadata.js` script as chatmodes are no longer part of the awesome-copilot repository structure
* Comment out chatmodes-related code including directory processing, metadata extraction, validation, and console output
* This cleanup ensures the script only processes active components (instructions, prompts, collections, and agents)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New feature to existing sample
[ ] New sample
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/microsoft/mcp-dotnet-samples.git
cd mcp-dotnet-samples
git checkout hotfix/remove-chatmodes
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd awesome-copilot
node update-metadata.js
# Verify that metadata.json is generated successfully without chatmodes
# Confirm no errors related to chatmodes directory or processing
```

## What to Check
Verify that the following are valid
* The `update-metadata.js` script runs without errors
* Generated `metadata.json` no longer contains a `chatmodes` property
* Only instructions, prompts, collections, and agents are processed
* Console output no longer includes chatmodes count
* No chatmodes validation errors occur

## Other Information
<!-- Add any other helpful information that may be needed here. -->
This change aligns the metadata script with the current structure of the awesome-copilot repository by removing references to the deprecated chatmodes feature. The code is commented out rather than deleted to maintain clarity about what was removed and why.