### PR TITLE
Add MCP registry details for awesome-copilot

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -80,6 +80,27 @@ jobs:
             git push origin main
           fi
 
+      - name: Get registry version
+        if: inputs.image_name == 'awesome-copilot'
+        id: registry
+        shell: pwsh
+        run: |
+          pushd awesome-copilot
+
+          $server = Get-Content ./server.json | ConvertFrom-Json
+          $version = $($server.version).Split(".")
+          $release = Get-Date -Format "yyyyMMddHH" -AsUTC
+
+          $revised = "$([string]::Join(".", $version[0..1])).$release"
+
+          $server.version = $revised
+          $server.packages[0].version = $revised
+          $server | ConvertTo-Json -Depth 10 | Out-File -FilePath ./server.json -Encoding utf8 -Force
+
+          echo "version=$revised" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          popd
+
       - name: Build app
         if: env.BUILD_IMAGE == 'true' || inputs.force == true
         shell: bash
@@ -124,10 +145,26 @@ jobs:
           steps.check-dockerfile.outputs.exists == 'true'
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image - multi-platform
+      - name: Build and push Docker image - multi-platform for awesome-copilot
         if: |
           (env.BUILD_IMAGE == 'true' || inputs.force == true) &&
-          steps.check-dockerfile.outputs.exists == 'true'
+          steps.check-dockerfile.outputs.exists == 'true' &&
+          inputs.image_name == 'awesome-copilot'
+        id: push-multiplatform
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: ${{ github.workspace }}
+          file: ${{ github.workspace }}/Dockerfile.${{ inputs.image_name }}
+          tags: '${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ inputs.image_name }}:latest,${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ inputs.image_name }}:${{ steps.registry.outputs.version }}'
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker image - multi-platform for other images
+        if: |
+          (env.BUILD_IMAGE == 'true' || inputs.force == true) &&
+          steps.check-dockerfile.outputs.exists == 'true' &&
+          inputs.image_name != 'awesome-copilot'
         id: push-multiplatform
         uses: docker/build-push-action@v6
         with:
@@ -147,3 +184,21 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ inputs.image_name }}
           subject-digest: ${{ steps.push-multiplatform.outputs.digest }}
           push-to-registry: true
+
+      - name: Install mcp-publisher
+        if: inputs.image_name == 'awesome-copilot'
+        shell: bash
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        if: inputs.image_name == 'awesome-copilot'
+        shell: bash
+        run: |
+          ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        if: inputs.image_name == 'awesome-copilot'
+        shell: bash
+        run: |
+          ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,5 @@ FodyWeavers.xsd
 *.sln.iml
 
 .DS_Store
+.mcpregistry_github_token
+.mcpregistry_registry_token

--- a/Dockerfile.awesome-copilot
+++ b/Dockerfile.awesome-copilot
@@ -17,6 +17,8 @@ RUN case "$TARGETARCH" in \
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 
+LABEL io.modelcontextprotocol.server.name="io.github.microsoft/awesome-copilot"
+
 WORKDIR /app
 
 COPY --from=build /app .

--- a/Dockerfile.awesome-copilot-azure
+++ b/Dockerfile.awesome-copilot-azure
@@ -11,6 +11,8 @@ RUN dotnet publish -c Release -o /app --self-contained false
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
 
+LABEL io.modelcontextprotocol.server.name="io.github.microsoft/awesome-copilot"
+
 WORKDIR /app
 
 COPY --from=build /app .

--- a/awesome-copilot/server.json
+++ b/awesome-copilot/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+
+  "name": "io.github.microsoft/awesome-copilot",
+  "title": "Awesome Copilot MCP Server",
+  "description": "An MCP server that stores Copilot customizations from the Awesome Copilot repository",
+
+  "repository": {
+    "url": "https://github.com/microsoft/mcp-dotnet-samples",
+    "source": "github"
+  },
+  "websiteUrl": "https://aka.ms/awesome-copilot/mcp",
+
+  "version": "1.0.0",
+
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/microsoft/mcp-dotnet-samples/awesome-copilot:latest",
+      "version": "1.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
* Add MCP registry support for the awesome-copilot sample so it can be published to the Model Context Protocol registry.
* Introduce `awesome-copilot/server.json` with server metadata (name, description, version, OCI package reference).
* Update the `build-container` workflow to compute a date-based registry version, tag the awesome-copilot image with that version, and publish to the MCP registry using `mcp-publisher`.
* Add the `io.modelcontextprotocol.server.name` label to both awesome-copilot Dockerfiles.
* Add MCP registry token files to `.gitignore`.

## Does this introduce a breaking change?
```n[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```n[ ] Bugfix
[x] New feature to existing sample
[ ] New sample
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

```n[ ] Yes
[ ] No
[x] N/A
```

## How to Test
* Get the code

```ngit clone https://github.com/microsoft/mcp-dotnet-samples
cd mcp-dotnet-samples
git checkout feat/registry
```

* Test the code
```n# Verify server.json is valid JSON
cat awesome-copilot/server.json | python -m json.tool

# Verify Dockerfile labels
grep -n 'io.modelcontextprotocol' Dockerfile.awesome-copilot Dockerfile.awesome-copilot-azure
```

## What to Check
Verify that the following are valid
* `awesome-copilot/server.json` contains correct server name, description, repository URL, and OCI package identifier
* The build-container workflow conditionally applies registry steps only for `awesome-copilot`
* Both Dockerfiles include the `io.modelcontextprotocol.server.name` label
* `.gitignore` includes MCP registry token files

## Other Information
The MCP registry publish steps use GitHub OIDC for authentication and only run for the awesome-copilot image.