### PR TITLE
Fix MCP server URL in README for HTTP switch

### DIFF
--- a/awesome-copilot/README.md
+++ b/awesome-copilot/README.md
@@ -64,12 +64,12 @@ Awesome Copilot MCP server includes:
 
    **Parameters**:
 
-   - `--http`: The switch that indicates to run this MCP server as a streamable HTTP type. When this switch is added, the MCP server URL is `http://localhost:5250`.
+   - `--http`: The switch that indicates to run this MCP server as a streamable HTTP type. When this switch is added, the MCP server URL is `http://localhost:5250/mcp`.
 
    With this parameter, you can run the MCP server like:
 
    ```bash
-   dotnet run --project ./src/McpSamples.AwesomeCopilot.HybridApp -- --http
+   dotnet run --project ./src/McpSamples.AwesomeCopilot.HybridApp --http
    ```
 
 #### In a container
@@ -95,7 +95,7 @@ Awesome Copilot MCP server includes:
 
    **Parameters**:
 
-   - `--http`: The switch that indicates to run this MCP server as a streamable HTTP type. When this switch is added, the MCP server URL is `http://localhost:8080`.
+   - `--http`: The switch that indicates to run this MCP server as a streamable HTTP type. When this switch is added, the MCP server URL is `http://localhost:8080/mcp`.
 
    With this parameter, you can run the MCP server like:
 


### PR DESCRIPTION
## Purpose
Updated MCP server URL in README to include '/mcp' path. The ealier instructions were missing the /mcp in the URL causing the instructions to not work. 


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] New feature to existing sample
[ ] New sample
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
 - Launch the MCP server locally using the command line (dotnet run) or docker instructions
 - Connect to the MCP with the documented URL
```

## What to Check
Verify that the following are valid
* Connect is successful

## Other Information
<!-- Add any other helpful information that may be needed here. -->